### PR TITLE
[6.x] Add execution scheduled task time

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -121,8 +121,9 @@ class ScheduleRunCommand extends Command
      */
     protected function runEvent($event)
     {
-        $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
-
+        $datetime = date('Y-m-d H:i:s');
+        $this->line("<info>[{$datetime}] Running scheduled command:</info> ".$event->getSummaryForDisplay());
+        
         $this->dispatcher->dispatch(new ScheduledTaskStarting($event));
 
         $start = microtime(true);


### PR DESCRIPTION
Add the time to execute the planned task, convenient to view the log, and judge whether our task is executed according to the plan.